### PR TITLE
added node pool attribute "temporary_name_for_rotation" to allow resizing k8s vms with only one node pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,39 @@ Type: `list(string)`
 
 Default: `[]`
 
-### automatic\_channel\_upgrade
+### auto\_scaling\_enable
 
-Description: Values: none, patch, stable, rapid, node-image
-for further information see https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-cluster
+Description: Enable auto-scaling of node pool
+
+Type: `bool`
+
+Default: `false`
+
+### auto\_scaling\_max\_node\_count
+
+Description: Enable auto-scaling of node pool
 
 Type: `string`
 
-Default: `none`
+Default: `"1"`
+
+### auto\_scaling\_min\_node\_count
+
+Description: Enable auto-scaling of node pool
+
+Type: `string`
+
+Default: `"1"`
+
+### automatic\_channel\_upgrade
+
+Description: Values:  
+none, patch, stable, rapid, node-image  
+see https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-cluster
+
+Type: `string`
+
+Default: `"none"`
 
 ### availability\_zones
 
@@ -189,6 +214,40 @@ Type: `string`
 
 Default: `"basic"`
 
+### maintenance\_window\_auto\_upgrade\_day\_of\_week
+
+Description: see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
+
+Type: `string`
+
+Default: `"Monday"`
+
+### maintenance\_window\_auto\_upgrade\_duration
+
+Description: see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
+
+Type: `string`
+
+Default: `"4"`
+
+### maintenance\_window\_auto\_upgrade\_start\_time
+
+Description: Example: "04:00"  
+see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
+
+Type: `string`
+
+Default: `"04:00"`
+
+### maintenance\_window\_auto\_upgrade\_utc\_offset
+
+Description: Example: "+00:00"  
+see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
+
+Type: `string`
+
+Default: `"+00:00"`
+
 ### managed\_identity\_security\_group
 
 Description: The name of a group which is assigned to appropriate roles in the subscription to manage resources that are required by the AKS.  
@@ -203,42 +262,6 @@ You need the following API permissions (with admin consent) on a service prinicp
 Type: `string`
 
 Default: `""`
-
-### maintenance\_window\_auto\_upgrade\_day\_of\_week
-
-Description: The maintenance window is automatically, if automatic\_channel\_upgrade != none
-for values see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
-
-Type: `string`
-
-Default: `"Monday"`
-
-### maintenance\_window\_auto\_upgrade\_duration
-
-Description: The maintenance window is automatically, if automatic\_channel\_upgrade != none
-for values see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
-
-Type: `string`
-
-Default: `"4"`
-
-### maintenance\_window\_auto\_upgrade\_start\_time
-
-Description: The maintenance window is automatically, if automatic\_channel\_upgrade != none
-for values see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
-
-Type: `string`
-
-Default: `"04:00"`
-
-### maintenance\_window\_auto\_upgrade\_utc\_offset
-
-Description: The maintenance window is automatically, if automatic\_channel\_upgrade != none
-for values see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
-
-Type: `string`
-
-Default: `"+00:00"`
 
 ### max\_pods
 
@@ -334,6 +357,14 @@ Description: Map of tags for the resources
 Type: `map(any)`
 
 Default: `{}`
+
+### temporary\_name\_for\_rotation
+
+Description: Specifies the name of the temporary node pool used to cycle the default node pool for VM resizing.
+
+Type: `string`
+
+Default: `"rotationtmp"`
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@
  */
 
 locals {
-  cluster_name = "${lower(var.project)}${lower(var.stage)}k8s"
+  cluster_name                                     = "${lower(var.project)}${lower(var.stage)}k8s"
   has_automatic_channel_upgrade_maintenance_window = var.automatic_channel_upgrade != "none" ? [var.automatic_channel_upgrade] : []
 }
 
@@ -30,27 +30,28 @@ resource "azurerm_kubernetes_cluster" "k8s" {
 
   automatic_channel_upgrade = var.automatic_channel_upgrade != "none" ? var.automatic_channel_upgrade : null
   dynamic "maintenance_window_auto_upgrade" {
-  for_each = local.has_automatic_channel_upgrade_maintenance_window
+    for_each = local.has_automatic_channel_upgrade_maintenance_window
     content {
-      frequency               = "Weekly"
-      interval                = "1"
-      duration                = var.maintenance_window_auto_upgrade_duration
-      day_of_week             = var.maintenance_window_auto_upgrade_day_of_week
-      start_time              = var.maintenance_window_auto_upgrade_start_time
-      utc_offset              = var.maintenance_window_auto_upgrade_utc_offset
+      frequency   = "Weekly"
+      interval    = "1"
+      duration    = var.maintenance_window_auto_upgrade_duration
+      day_of_week = var.maintenance_window_auto_upgrade_day_of_week
+      start_time  = var.maintenance_window_auto_upgrade_start_time
+      utc_offset  = var.maintenance_window_auto_upgrade_utc_offset
     }
   }
 
   default_node_pool {
-    name                 = var.default_node_pool_name
-    type                 = "VirtualMachineScaleSets"
-    node_count           = var.node_count
-    vm_size              = var.vm_size
-    os_disk_size_gb      = var.node_storage
-    vnet_subnet_id       = var.subnet_id
-    max_pods             = var.max_pods
-    orchestrator_version = var.default_node_pool_k8s_version
-    zones                = var.availability_zones
+    name                        = var.default_node_pool_name
+    type                        = "VirtualMachineScaleSets"
+    node_count                  = var.node_count
+    vm_size                     = var.vm_size
+    os_disk_size_gb             = var.node_storage
+    vnet_subnet_id              = var.subnet_id
+    max_pods                    = var.max_pods
+    orchestrator_version        = var.default_node_pool_k8s_version
+    zones                       = var.availability_zones
+    temporary_name_for_rotation = var.temporary_name_for_rotation
   }
 
   dynamic "api_server_access_profile" {

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,9 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     orchestrator_version        = var.default_node_pool_k8s_version
     zones                       = var.availability_zones
     temporary_name_for_rotation = var.temporary_name_for_rotation
+    enable_auto_scaling         = var.auto_scaling_enable
+    min_count                   = var.auto_scaling_min_node_count
+    max_count                   = var.auto_scaling_max_node_count
   }
 
   dynamic "api_server_access_profile" {

--- a/vars.tf
+++ b/vars.tf
@@ -95,21 +95,21 @@ variable "node_pools" {
 }
 
 variable "auto_scaling_enable" {
-  type = bool
-  description = "Enable auto scaling of node pool"
-  default = false
+  type        = bool
+  description = "Enable auto-scaling of node pool"
+  default     = false
 }
 
 variable "auto_scaling_min_node_count" {
-  type = string
-  description = "Enable auto scaling of node pool"
-  default = "1"
+  type        = string
+  description = "Enable auto-scaling of node pool"
+  default     = "1"
 }
 
 variable "auto_scaling_max_node_count" {
-  type = string
-  description = "Enable auto scaling of node pool"
-  default = "1"
+  type        = string
+  description = "Enable auto-scaling of node pool"
+  default     = "1"
 }
 
 variable "load_balancer_sku" {
@@ -131,9 +131,9 @@ variable "availability_zones" {
 }
 
 variable "temporary_name_for_rotation" {
-  type = string
+  type        = string
   description = "Specifies the name of the temporary node pool used to cycle the default node pool for VM resizing."
-  default = "rotationtmp"
+  default     = "rotationtmp"
 }
 
 variable "sku_tier" {
@@ -228,7 +228,7 @@ variable "automatic_channel_upgrade" {
 variable "maintenance_window_auto_upgrade_day_of_week" {
   type        = string
   default     = "Monday"
-  description  =  <<-EOF
+  description = <<-EOF
     see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
   EOF
 }
@@ -236,7 +236,7 @@ variable "maintenance_window_auto_upgrade_day_of_week" {
 variable "maintenance_window_auto_upgrade_duration" {
   type        = string
   default     = "4"
-  description  =  <<-EOF
+  description = <<-EOF
     see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
   EOF
 }
@@ -244,7 +244,7 @@ variable "maintenance_window_auto_upgrade_duration" {
 variable "maintenance_window_auto_upgrade_start_time" {
   type        = string
   default     = "04:00"
-  description  =  <<-EOF
+  description = <<-EOF
     Example: "04:00"
     see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
   EOF
@@ -253,7 +253,7 @@ variable "maintenance_window_auto_upgrade_start_time" {
 variable "maintenance_window_auto_upgrade_utc_offset" {
   type        = string
   default     = "+00:00"
-  description  =  <<-EOF
+  description = <<-EOF
     Example: "+00:00"
     see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
   EOF

--- a/vars.tf
+++ b/vars.tf
@@ -92,7 +92,24 @@ variable "node_pools" {
   }))
   default     = {}
   description = "Additional node pools to set up"
+}
 
+variable "auto_scaling_enable" {
+  type = bool
+  description = "Enable auto scaling of node pool"
+  default = false
+}
+
+variable "auto_scaling_min_node_count" {
+  type = string
+  description = "Enable auto scaling of node pool"
+  default = "1"
+}
+
+variable "auto_scaling_max_node_count" {
+  type = string
+  description = "Enable auto scaling of node pool"
+  default = "1"
 }
 
 variable "load_balancer_sku" {

--- a/vars.tf
+++ b/vars.tf
@@ -116,7 +116,7 @@ variable "availability_zones" {
 variable "temporary_name_for_rotation" {
   type = string
   description = "Specifies the name of the temporary node pool used to cycle the default node pool for VM resizing."
-  default = "default_rotation_tmp"
+  default = "rotationtmp"
 }
 
 variable "sku_tier" {

--- a/vars.tf
+++ b/vars.tf
@@ -113,6 +113,12 @@ variable "availability_zones" {
   default     = []
 }
 
+variable "temporary_name_for_rotation" {
+  type = string
+  description = "Specifies the name of the temporary node pool used to cycle the default node pool for VM resizing."
+  default = "default_rotation_tmp"
+}
+
 variable "sku_tier" {
   type    = string
   default = "Free"


### PR DESCRIPTION
added node pool attribute "temporary_name_for_rotation" to allow resizing k8s vms with only one node pool