### PR TITLE
feat: pool upgrade settings, separate rbac_enabled for azure_active_directory_role_based_access_control, node_count as output parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,22 @@ Type: `string`
 
 Default: `"default"`
 
+### default\_node\_pool\_upgrade\_settings\_enabled
+
+Description: default upgrade settings is added to default node pool
+
+Type: `boolean`
+
+Default: `false`
+
+### default\_node\_pool\_upgrade\_settings\_max\_surge
+
+Description: max surge of upgrade settings for default node pool
+
+Type: `string`
+
+Default: `"10%"`
+
 ### dns\_prefix
 
 Description: DNS-Prefix to use. Defaults to cluster name

--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+### ad\_rbac\_enabled
+
+Description: Defines RBAC for block azure\_active\_directory\_role\_based\_access\_control explicitly if set.  
+Else RBAC for block azure\_active\_directory\_role\_based\_access\_control is set by "rbac\_enabled"
+
+Type: `bool`
+
+Default: `null`
+
 ### api\_server\_ip\_ranges
 
 Description: The IP ranges to allow for incoming traffic to the server nodes. To disable the limitation, set an empty list as value (default).
@@ -132,7 +141,7 @@ Type: `list(string)`
 
 Default: `[]`
 
-### auto\_scaling\_enable
+### auto\_scaling\_enabled
 
 Description: Enable auto-scaling of node pool
 
@@ -156,7 +165,7 @@ Type: `string`
 
 Default: `"1"`
 
-### automatic\_channel\_upgrade
+### automatic\_upgrade\_channel
 
 Description: Values:  
 none, patch, stable, rapid, node-image  
@@ -192,15 +201,17 @@ Default: `"default"`
 
 ### default\_node\_pool\_upgrade\_settings\_enabled
 
-Description: default upgrade settings is added to default node pool
+Description: Values:  
+false, true
 
-Type: `boolean`
+Type: `bool`
 
 Default: `false`
 
 ### default\_node\_pool\_upgrade\_settings\_max\_surge
 
-Description: max surge of upgrade settings for default node pool
+Description: Example: "10%"  
+see https://learn.microsoft.com/en-us/azure/aks/upgrade-aks-cluster?tabs=azure-cli#customize-node-surge-upgrade
 
 Type: `string`
 
@@ -221,6 +232,22 @@ Description: Desired outbound flow idle timeout in minutes for the cluster load 
 Type: `number`
 
 Default: `5`
+
+### image\_cleaner\_enabled
+
+Description: Azure default settings
+
+Type: `bool`
+
+Default: `false`
+
+### image\_cleaner\_interval\_hours
+
+Description: Azure default settings
+
+Type: `number`
+
+Default: `48`
 
 ### load\_balancer\_sku
 
@@ -433,6 +460,10 @@ Description: The Kubernetes API host for a kubectl config
 ### managed\_identity\_object\_id
 
 Description: The object ID of the service principal of the managed identity of the AKS
+
+### node\_count
+
+Description: n/a
 
 ### node\_resource\_group
 

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,9 @@ locals {
   has_automatic_channel_upgrade_maintenance_window = var.automatic_upgrade_channel != "none" ? [
     var.automatic_upgrade_channel
   ] : []
+  has_default_node_pool_upgrade_settings = var.default_node_pool_upgrade_settings_enabled == true ? [
+    var.default_node_pool_upgrade_settings_enabled
+  ] : []
 }
 
 # Log analytics required for OMS Agent result processing - usually other logging solutions are used. Hence the affected tfsec rule is
@@ -61,6 +64,12 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     auto_scaling_enabled        = var.auto_scaling_enabled
     min_count                   = var.auto_scaling_min_node_count
     max_count                   = var.auto_scaling_max_node_count
+    dynamic "upgrade_settings" {
+      for_each = local.has_default_node_pool_upgrade_settings
+      content {
+        max_surge               = var.default_node_pool_upgrade_settings_max_surge
+      }
+    }
   }
 
   dynamic "api_server_access_profile" {

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@
  */
 
 locals {
-  cluster_name                                     = "${lower(var.project)}${lower(var.stage)}k8s"
+  cluster_name = "${lower(var.project)}${lower(var.stage)}k8s"
   has_automatic_channel_upgrade_maintenance_window = var.automatic_upgrade_channel != "none" ? [
     var.automatic_upgrade_channel
   ] : []
@@ -67,7 +67,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     dynamic "upgrade_settings" {
       for_each = local.has_default_node_pool_upgrade_settings
       content {
-        max_surge               = var.default_node_pool_upgrade_settings_max_surge
+        max_surge = var.default_node_pool_upgrade_settings_max_surge
       }
     }
   }
@@ -86,7 +86,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   role_based_access_control_enabled = var.rbac_enabled
   azure_active_directory_role_based_access_control {
     admin_group_object_ids = var.rbac_managed_admin_groups
-    azure_rbac_enabled     = var.rbac_enabled
+    azure_rbac_enabled     = var.ad_rbac_enabled != null ? var.ad_rbac_enabled : var.rbac_enabled
   }
 
   network_profile {

--- a/outputs.tf
+++ b/outputs.tf
@@ -67,3 +67,7 @@ output "managed_identity_object_id" {
   value       = azurerm_kubernetes_cluster.k8s.identity[0].principal_id
   description = "The object ID of the service principal of the managed identity of the AKS"
 }
+
+output "node_count" {
+  value = var.node_count
+}

--- a/vars.tf
+++ b/vars.tf
@@ -270,3 +270,21 @@ variable "maintenance_window_auto_upgrade_utc_offset" {
     see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance#creating-a-maintenance-window
   EOF
 }
+
+variable "default_node_pool_upgrade_settings_enabled" {
+  type        = bool
+  default     = false
+  description = <<-EOF
+    Values:
+    false, true
+  EOF
+}
+
+variable "default_node_pool_upgrade_settings_max_surge" {
+  type        = string
+  default     = "10%"
+  description = <<-EOF
+    Example: "10%"
+    see https://learn.microsoft.com/en-us/azure/aks/upgrade-aks-cluster?tabs=azure-cli#customize-node-surge-upgrade
+  EOF
+}

--- a/vars.tf
+++ b/vars.tf
@@ -142,6 +142,10 @@ variable "availability_zones" {
 variable "temporary_name_for_rotation" {
   type        = string
   description = "Specifies the name of the temporary node pool used to cycle the default node pool for VM resizing."
+  validation {
+    condition     = var.temporary_name_for_rotation != null
+    error_message = "The temporary_name_for_rotation value must not be null"
+  }
   default     = "rotationtmp"
 }
 

--- a/vars.tf
+++ b/vars.tf
@@ -62,6 +62,15 @@ variable "rbac_enabled" {
   default     = true
 }
 
+variable "ad_rbac_enabled" {
+  type        = bool
+  description = <<-EOF
+    Defines RBAC for block azure_active_directory_role_based_access_control explicitly if set.
+    Else RBAC for block azure_active_directory_role_based_access_control is set by "rbac_enabled"
+  EOF
+  default     = null
+}
+
 variable "rbac_managed_admin_groups" {
   type        = list(string)
   description = "The group IDs that have admin access to the cluster. Have to be specified if rbac_enabled is true"


### PR DESCRIPTION
This PR contains several features and fixes an issue. 

After discussion with @dploeger I put it altogether in this PR, because in 1 commit I regenerated the documentation, which would introduce merge conflicts, if each commit was in its own PR.

[feat: configure adding default node pool upgrade settings](https://github.com/dodevops/terraform-azure-kubernetes/commit/4f754ae9988e55e600652d4d302488cd4715853f)
[feat: use input parameter node_count as output parameter](https://github.com/dodevops/terraform-azure-kubernetes/commit/40ba59900c871cb44ce9e9b5f44eac530ce48bc0)
[feat: configure azure_rbac_enabled for azure_active_directory_role_ba…](https://github.com/dodevops/terraform-azure-kubernetes/commit/6df4dda6af1991c09455d5714f7a9307105267f6)
[fix: The temporary_name_for_rotation value must not be null](https://github.com/dodevops/terraform-azure-kubernetes/commit/ffffc7e5a4f4a4af6427af491d9f872ca3d33cff)