### PR TITLE
feat: add k8s nodepool drain_timeout_in_minutes and node_soak_duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,26 @@ Type: `string`
 
 Default: `"default"`
 
+### default\_node\_pool\_node\_soak\_duration\_in\_minutes
+
+Description: soak\_duration\_in\_minutes is a optional parameter for an upgrade\_settings block  
+Example: "30"  
+see https://learn.microsoft.com/en-us/azure/aks/upgrade-aks-cluster?tabs=azure-cli#set-node-soak-time-value
+
+Type: `number`
+
+Default: `0`
+
+### default\_node\_pool\_upgrade\_settings\_drain\_timeout\_in\_minutes
+
+Description: drain\_timeout\_in\_minutes is a optional parameter for an upgrade\_settings block  
+Example: "30"  
+see https://learn.microsoft.com/en-us/azure/aks/upgrade-aks-cluster?tabs=azure-cli#set-node-drain-timeout-value
+
+Type: `number`
+
+Default: `30`
+
 ### default\_node\_pool\_upgrade\_settings\_enabled
 
 Description: If true, an upgrade\_settings block will be added to default\_node\_pool.

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,9 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     dynamic "upgrade_settings" {
       for_each = local.has_default_node_pool_upgrade_settings
       content {
-        max_surge = var.default_node_pool_upgrade_settings_max_surge
+        max_surge                     = var.default_node_pool_upgrade_settings_max_surge
+        drain_timeout_in_minutes      = var.default_node_pool_upgrade_settings_drain_timeout_in_minutes
+        node_soak_duration_in_minutes = var.default_node_pool_node_soak_duration_in_minutes
       }
     }
   }

--- a/vars.tf
+++ b/vars.tf
@@ -301,3 +301,31 @@ variable "default_node_pool_upgrade_settings_max_surge" {
     see https://learn.microsoft.com/en-us/azure/aks/upgrade-aks-cluster?tabs=azure-cli#customize-node-surge-upgrade
   EOF
 }
+
+variable "default_node_pool_upgrade_settings_drain_timeout_in_minutes" {
+  type        = number
+  description = <<-EOF
+    drain_timeout_in_minutes is a optional parameter for an upgrade_settings block
+    Example: "30"
+    see https://learn.microsoft.com/en-us/azure/aks/upgrade-aks-cluster?tabs=azure-cli#set-node-drain-timeout-value
+  EOF
+  validation {
+    condition     = var.default_node_pool_upgrade_settings_drain_timeout_in_minutes >= 0 && var.default_node_pool_upgrade_settings_drain_timeout_in_minutes <= 60
+    error_message = "default_node_pool_upgrade_settings_drain_timeout_in_minutes has to be between 0 and 60 including."
+  }
+  default = 30
+}
+
+variable "default_node_pool_node_soak_duration_in_minutes" {
+  type        = number
+  description = <<-EOF
+    soak_duration_in_minutes is a optional parameter for an upgrade_settings block
+    Example: "30"
+    see https://learn.microsoft.com/en-us/azure/aks/upgrade-aks-cluster?tabs=azure-cli#set-node-soak-time-value
+  EOF
+  validation {
+    condition     = var.default_node_pool_node_soak_duration_in_minutes >= 0 && var.default_node_pool_node_soak_duration_in_minutes <= 60
+    error_message = "default_node_pool_node_soak_duration_in_minutes has to be between 0 and 60 including."
+  }
+  default = 0
+}


### PR DESCRIPTION
Hi, i've added two new node pool settings: drain_timeout_in_minutes and node_soak_duration_in_minutes