### PR TITLE
COMPATIBILITY: force_upgrade_enabled can now be defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,14 @@ Type: `string`
 
 Default: `"NONE"`
 
+### force\_upgrade\_enabled
+
+Description: Azure default settings
+
+Type: `bool`
+
+Default: `false`
+
 ### idle\_timeout
 
 Description: Desired outbound flow idle timeout in minutes for the cluster load balancer. Must be between 4 and 120 inclusive.

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,10 @@ resource "azurerm_kubernetes_cluster" "k8s" {
 
   automatic_upgrade_channel = var.automatic_upgrade_channel != "none" ? var.automatic_upgrade_channel : null
 
+  upgrade_override {
+    force_upgrade_enabled = var.force_upgrade_enabled
+  }
+
   dynamic "maintenance_window_auto_upgrade" {
     for_each = local.has_automatic_channel_upgrade_maintenance_window
     content {

--- a/vars.tf
+++ b/vars.tf
@@ -379,3 +379,9 @@ variable "default_node_pool_node_soak_duration_in_minutes" {
   }
   default = 0
 }
+
+variable "force_upgrade_enabled" {
+  description = "Azure default settings"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
COMPATIBILITY: force_upgrade_enabled can now be defined. The Azure default changed as it cannot be unset now