### PR TITLE
COMPATIBILITY: force_upgrade_enabled can be null

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,13 +255,21 @@ Type: `string`
 
 Default: `"NONE"`
 
+### force\_upgrade\_effective\_until
+
+Description: RFC3339 timestamp for upgrade\_override.effective\_until. Example: 2026-07-20T23:59:59Z
+
+Type: `string`
+
+Default: `null`
+
 ### force\_upgrade\_enabled
 
-Description: Azure default settings
+Description: Azure default settings: When null, the complete block is omitted
 
 Type: `bool`
 
-Default: `false`
+Default: `null`
 
 ### idle\_timeout
 

--- a/main.tf
+++ b/main.tf
@@ -41,8 +41,12 @@ resource "azurerm_kubernetes_cluster" "k8s" {
 
   automatic_upgrade_channel = var.automatic_upgrade_channel != "none" ? var.automatic_upgrade_channel : null
 
-  upgrade_override {
-    force_upgrade_enabled = var.force_upgrade_enabled
+  dynamic "upgrade_override" {
+    for_each = var.force_upgrade_enabled == null ? [] : [var.force_upgrade_enabled]
+    content {
+      force_upgrade_enabled = upgrade_override.value
+      effective_until       = var.force_upgrade_effective_until
+    }
   }
 
   dynamic "maintenance_window_auto_upgrade" {

--- a/vars.tf
+++ b/vars.tf
@@ -381,7 +381,14 @@ variable "default_node_pool_node_soak_duration_in_minutes" {
 }
 
 variable "force_upgrade_enabled" {
-  description = "Azure default settings"
+  description = "Azure default settings: When null, the complete block is omitted"
   type        = bool
-  default     = false
+  nullable    = true
+  default     = null
+}
+
+variable "force_upgrade_effective_until" {
+  description = "RFC3339 timestamp for upgrade_override.effective_until. Example: 2026-07-20T23:59:59Z"
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
COMPATIBILITY: force_upgrade_enabled can be null to omit the complete block. Possible variables force_upgrade_enabled and force_upgrade_effective_until can be overridden as needed