### PR TITLE
feat: Compatibility with AzureRM 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,22 @@ map(object({
 
 Default: `{}`
 
+### node\_provisioning\_profile\_default\_node\_pools
+
+Description: Valid options: Auto, None
+
+Type: `string`
+
+Default: `"Auto"`
+
+### node\_provisioning\_profile\_mode
+
+Description: Valid options: Auto, Manual
+
+Type: `string`
+
+Default: `"Manual"`
+
 ### node\_storage
 
 Description: Disk size in GB
@@ -439,6 +455,14 @@ Description: Disk size in GB
 Type: `string`
 
 Default: `"30"`
+
+### oidc\_issuer\_enabled
+
+Description: Whether to enable the OIDC issuer feature. With AzureRM 5.x.x the default changed to true if not specified explicitly
+
+Type: `bool`
+
+Default: `false`
 
 ### outbound\_ports\_allocated
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following requirements are needed by this module:
 
 - azuread (>=2.41.0)
 
-- azurerm (>=3.63.0)
+- azurerm (>=4.57.0)
 
 ## Providers
 
@@ -39,7 +39,7 @@ The following providers are used by this module:
 
 - azuread (>=2.41.0)
 
-- azurerm (>=3.63.0)
+- azurerm (>=4.57.0)
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -128,6 +128,13 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     }
   }
 
+  oidc_issuer_enabled = var.oidc_issuer_enabled
+
+  node_provisioning_profile {
+    mode               = var.node_provisioning_profile_mode
+    default_node_pools = var.node_provisioning_profile_default_node_pools
+  }
+
   dynamic "linux_profile" {
     for_each = var.ssh_public_key == "" ? [] : [var.ssh_public_key]
     content {

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.63.0"
+      version = ">=4.57.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/vars.tf
+++ b/vars.tf
@@ -392,3 +392,21 @@ variable "force_upgrade_effective_until" {
   type        = string
   default     = null
 }
+
+variable "oidc_issuer_enabled" {
+  description = "Whether to enable the OIDC issuer feature. With AzureRM 5.x.x the default changed to true if not specified explicitly"
+  type        = bool
+  default     = false
+}
+
+variable "node_provisioning_profile_mode" {
+  description = "Valid options: Auto, Manual"
+  type        = string
+  default     = "Manual"
+}
+
+variable "node_provisioning_profile_default_node_pools" {
+  description = "Valid options: Auto, None"
+  type        = string
+  default     = "Auto"
+}


### PR DESCRIPTION
COMPATIBILITY: oidc_issuer_enabled can now be defined. The Azure default changed
COMPATIBILITY: node_provisioning_profile_mode can now be defined. Using default without setting it is no longer possible
COMPATIBILITY: node_provisioning_profile_default_node_pools can now be defined. Using default without setting it is no longer possible